### PR TITLE
Retrieve all paginated repositories/tags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,11 +2,12 @@ package cmd
 
 import (
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/JLevconoks/registryViewer/app"
 	"github.com/JLevconoks/registryViewer/registry"
 	"github.com/spf13/cobra"
-	"os"
-	"strings"
 )
 
 var rootCmd = &cobra.Command{
@@ -16,8 +17,9 @@ var rootCmd = &cobra.Command{
 }
 
 var (
-	buildVersion = ""
-	buildTime    = ""
+	buildVersion    = ""
+	buildTime       = ""
+	paginationLimit int
 )
 
 func Execute() {
@@ -29,6 +31,7 @@ func Execute() {
 
 func init() {
 	rootCmd.Version = fmt.Sprintf("%s (%s)", buildVersion, buildTime)
+	rootCmd.Flags().IntVar(&paginationLimit, "limit", 1000, "maximum number of items per request to fetch from the registry")
 }
 
 func runRootCmd(cmd *cobra.Command, args []string) {
@@ -54,7 +57,7 @@ func runRootCmd(cmd *cobra.Command, args []string) {
 	}
 	subPath = strings.TrimSuffix(subPath, "/")
 
-	registryClient := registry.NewRegistry(protocol, baseUrl, subPath)
+	registryClient := registry.NewRegistry(protocol, baseUrl, subPath, paginationLimit)
 	guiApp := app.NewApp(registryClient)
 	guiApp.Run()
 }

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -2,17 +2,21 @@ package registry
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"sort"
 	"strings"
 )
 
 type Registry struct {
-	Protocol string
-	BaseUrl  string
-	SubPath  string
-	client   *http.Client
+	Protocol        string
+	BaseUrl         string
+	SubPath         string
+	client          *http.Client
+	paginationLimit int
 }
 
 type TokenTransport struct {
@@ -36,52 +40,63 @@ func (t *TokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return resp, err
 }
 
-func NewRegistry(protocol, baseUrl, subPath string) Registry {
+func NewRegistry(protocol, baseUrl, subPath string, paginationLimit int) Registry {
 	transport := &TokenTransport{http.DefaultTransport}
 	c := &http.Client{
 		Transport: transport,
 	}
-	return Registry{client: c,
-		Protocol: protocol,
-		BaseUrl:  baseUrl,
-		SubPath:  subPath,
+	return Registry{
+		client:          c,
+		Protocol:        protocol,
+		BaseUrl:         baseUrl,
+		SubPath:         subPath,
+		paginationLimit: paginationLimit,
 	}
 }
 
 func (r *Registry) ListRepositories() ([]string, error) {
-	url := fmt.Sprintf("%v://%v/v2/_catalog?n=10000", r.Protocol, r.BaseUrl)
-	resp, err := r.getWithAuth(url)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer resp.Body.Close()
+	repositories := make([]string, 0, r.paginationLimit)
+	baseUrl := fmt.Sprintf("%v://%v", r.Protocol, r.BaseUrl)
+	next := fmt.Sprintf("/v2/_catalog?n=%d", r.paginationLimit)
 
-	var repos repositoriesResponse
-	decoder := json.NewDecoder(resp.Body)
-	err = decoder.Decode(&repos)
-	if err != nil {
-		return nil, err
+	for next != "" {
+		responseRepositories, link, err := r.getNextRepositories(baseUrl, next)
+		if err != nil {
+			return nil, err
+		}
+
+		next, err = parseLink(link)
+		if err != nil {
+			return nil, err
+		}
+
+		repositories = append(repositories, responseRepositories...)
 	}
 
-	return repos.Repositories, nil
+	sort.Strings(repositories)
+	return repositories, nil
 }
 
 func (r *Registry) Tags(name string) ([]string, error) {
-	requestUrl := fmt.Sprintf("%v://%v/v2/%v%v/tags/list?n=10000", r.Protocol, r.BaseUrl, r.SubPath, name)
+	tags := make([]string, 0, r.paginationLimit)
+	baseUrl := fmt.Sprintf("%v://%v", r.Protocol, r.BaseUrl)
+	next := fmt.Sprintf("/v2/%v%v/tags/list?n=%d", r.SubPath, name, r.paginationLimit)
 
-	resp, err := r.getWithAuth(requestUrl)
-	if err != nil {
-		return nil, err
+	for next != "" {
+		responseTags, link, err := r.getNextTags(baseUrl, next)
+		if err != nil {
+			return nil, err
+		}
+
+		next, err = parseLink(link)
+		if err != nil {
+			return nil, err
+		}
+
+		tags = append(tags, responseTags...)
 	}
 
-	var tags tagsResponse
-	decoder := json.NewDecoder(resp.Body)
-	err = decoder.Decode(&tags)
-	if err != nil {
-		return nil, err
-	}
-
-	return tags.Tags, nil
+	return tags, nil
 }
 
 func (r *Registry) getWithAuth(url string) (*http.Response, error) {
@@ -97,7 +112,16 @@ func (r *Registry) getWithAuth(url string) (*http.Response, error) {
 			return nil, err
 		}
 		request.Header.Add("Authorization", "Bearer "+token.AuthToken)
-		resp, err = r.client.Do(request)
+		return r.client.Do(request)
+	}
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		buf := new(strings.Builder)
+		n, _ := io.Copy(buf, resp.Body)
+		if n > 0 {
+			return nil, errors.New(buf.String())
+		}
+		return nil, errors.New("unable to fetch")
 	}
 
 	return resp, err
@@ -130,6 +154,9 @@ func (r *Registry) getAuthToken(resp *http.Response) authToken {
 	query.Add("scope", paramMap["scope"])
 	request.URL.RawQuery = query.Encode()
 	response, err := r.client.Do(request)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	var token authToken
 	decoder := json.NewDecoder(response.Body)
@@ -139,4 +166,58 @@ func (r *Registry) getAuthToken(resp *http.Response) authToken {
 	}
 
 	return token
+}
+
+func parseLink(link string) (string, error) {
+	if link == "" {
+		return link, nil
+	}
+
+	start := strings.Index(link, "/v2/")
+	if start == -1 {
+		return "", fmt.Errorf("link header must contain '/v2/' [%s]", link)
+	}
+
+	end := strings.Index(link, ">")
+	if end == -1 {
+		return "", fmt.Errorf("link header must contain '>' [%s]", link)
+	}
+
+	return link[start:end], nil
+}
+
+func (r *Registry) getNextRepositories(baseUrl string, next string) ([]string, string, error) {
+	url := fmt.Sprintf("%v%v", baseUrl, next)
+	resp, err := r.getWithAuth(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var repos repositoriesResponse
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&repos)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return repos.Repositories, resp.Header.Get("Link"), nil
+}
+
+func (r *Registry) getNextTags(baseUrl string, next string) ([]string, string, error) {
+	url := fmt.Sprintf("%v%v", baseUrl, next)
+	resp, err := r.getWithAuth(url)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer resp.Body.Close()
+
+	var tags tagsResponse
+	decoder := json.NewDecoder(resp.Body)
+	err = decoder.Decode(&tags)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return tags.Tags, resp.Header.Get("Link"), nil
 }


### PR DESCRIPTION
**Change**
- Retrieve all repositories/tags rather than only the first 10000 by following the Link header returned 
- Allow the number of repositories fetched per request to be customised
- Handle all non 2xx responses from the registry

**Why**
- Some repositories appear to be "missing" when there are more than 10000 in a registry
- Some registries also limit the maximum number of repositories per request (ECR defaults to 1000 for example), currently this fails silently and the registry appears empty